### PR TITLE
Make FontMap::set_default() a static function and allow passing None …

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -114,3 +114,6 @@ manual_traits = ["FontMapExtManual"]
     [[object.function]]
     name = "new"
     ignore = true
+    [[object.function]]
+    name = "set_default"
+    ignore = true

--- a/src/auto/font_map.rs
+++ b/src/auto/font_map.rs
@@ -27,8 +27,6 @@ pub const NONE_FONT_MAP: Option<&FontMap> = None;
 pub trait FontMapExt: 'static {
     fn get_resolution(&self) -> f64;
 
-    fn set_default(&self);
-
     fn set_resolution(&self, dpi: f64);
 }
 
@@ -36,12 +34,6 @@ impl<O: IsA<FontMap>> FontMapExt for O {
     fn get_resolution(&self) -> f64 {
         unsafe {
             pango_cairo_sys::pango_cairo_font_map_get_resolution(self.as_ref().to_glib_none().0)
-        }
-    }
-
-    fn set_default(&self) {
-        unsafe {
-            pango_cairo_sys::pango_cairo_font_map_set_default(self.as_ref().to_glib_none().0);
         }
     }
 

--- a/src/font_map.rs
+++ b/src/font_map.rs
@@ -34,4 +34,10 @@ impl FontMap {
     pub fn new() -> Option<pango::FontMap> {
         unsafe { from_glib_full(pango_cairo_sys::pango_cairo_font_map_new()) }
     }
+
+    pub fn set_default(font_map: Option<Self>) {
+        unsafe {
+            pango_cairo_sys::pango_cairo_font_map_set_default(font_map.as_ref().to_glib_none().0);
+        }
+    }
 }


### PR DESCRIPTION
…as it's nullable

Fixes https://github.com/gtk-rs/pangocairo/issues/60

----

CC @GuillaumeGomez No new gir run needed in this repo :)